### PR TITLE
webkitCancelRequestAnimationFrame fix for android

### DIFF
--- a/js/lwf-loader.js
+++ b/js/lwf-loader.js
@@ -51,7 +51,9 @@
     global.msCancelAnimationFrame;
 
   /** apply polyfills for iOS6 devices */
-  if (global.requestAnimationFrame === undefined || /iP(ad|hone|od).*OS 6/.test(userAgent)) {
+  if (global.requestAnimationFrame === undefined
+      || global.cancelAnimationFrame === undefined
+      || /iP(ad|hone|od).*OS 6/.test(userAgent)) {
     (function() {
       var vsync = 1000 / 60;
       var t0 = global.performance.now();
@@ -64,11 +66,7 @@
           myCallback();
         }, d);
       };
-    })();
-  }
 
-  if (global.cancelAnimationFrame === undefined || /iP(ad|hone|od).*OS 6/.test(userAgent)) {
-    (function() {
       global.cancelAnimationFrame = function(timer) {
         return global.clearTimeout(timer);
       };

--- a/js/lwf-loader.js
+++ b/js/lwf-loader.js
@@ -45,6 +45,7 @@
 
   global.cancelAnimationFrame = global.cancelAnimationFrame ||
     global.webkitCancelAnimationFrame ||
+    global.webkitCancelRequestAnimationFrame ||
     global.mozCancelAnimationFrame ||
     global.oCancelAnimationFrame ||
     global.msCancelAnimationFrame;
@@ -63,7 +64,11 @@
           myCallback();
         }, d);
       };
+    })();
+  }
 
+  if (global.cancelAnimationFrame === undefined || /iP(ad|hone|od).*OS 6/.test(userAgent)) {
+    (function() {
       global.cancelAnimationFrame = function(timer) {
         return global.clearTimeout(timer);
       };


### PR DESCRIPTION
Excuse me. A bug is found on early android 4 devices which may only provide `webkitCancelRequestAnimationFrame` interface, and here's a fix.
